### PR TITLE
Allow host configuration when initializing settings

### DIFF
--- a/communication.py
+++ b/communication.py
@@ -8,7 +8,8 @@ import os
 window = None
 sio = socketio.Client()
 stop_signal = {"stop": False}
-token = load_config()  # Carga el token desde la configuración
+config = load_config()  # Carga la configuración
+token = config.get('token')
 sio.token = token
 class CodeRunner(threading.Thread):
     def __init__(self, code,jobid, stop_signal):
@@ -25,7 +26,7 @@ class CodeRunner(threading.Thread):
         output="{}"
         try:
             from actions import dblclick_text,hover_simple,wait_exists, wait_exists_text,is_text_visible,click_text,rightclick,mkdir,up,down,right,left, press,press2, sleep, click, dblclick, wait_exists, exists, leer, escribir_texto, teclear, chatGPT, agregar_a_excel, email
-            sio.token = load_config()
+            sio.token = load_config().get('token')
             # Añadir las funciones importadas al namespace local
             local_namespace.update({
                 "up": up,

--- a/config.json
+++ b/config.json
@@ -1,2 +1,2 @@
-{"token": "6777f8277fe07edb26c63a3d"}
+{"token": "6777f8277fe07edb26c63a3d", "server": "https://autom.be"}
 

--- a/ui.py
+++ b/ui.py
@@ -5,12 +5,9 @@ from PyQt5.QtCore import QTimer
 from PyQt5.QtGui import QMovie
 from PyQt5.QtWidgets import QSpacerItem, QSizePolicy
 from PyQt5.QtGui import QPixmap
-
-
-import os
-import json
 import time
 from communication import sio, CodeRunner, stop_signal
+from utils import load_config, save_config
 
 import pygame
 from sounds import generate_r2d2_hello_sound,generate_r2d2_yeah_sound,generate_r2d2_help_sound
@@ -64,7 +61,6 @@ class MainWindow(QMainWindow):
         self.button.setText("Connect/Disconnect")
         self.code_runner = CodeRunner("",0, stop_signal)
         self.setWindowIcon(QIcon('logo.ico'))
-        sio.token = self.obtener_token()
         QTimer.singleShot(10, self.conectar)
         
     def show_continue_button(self):
@@ -105,12 +101,16 @@ class MainWindow(QMainWindow):
         self.error()
 
     def conectar(self):
-        sio.token = self.obtener_token()
-        if sio.token:
+        config = self.obtener_config()
+        if config:
+            sio.token = config.get('token')
+            global server
+            server_url = config.get('server', server)
+            server = server_url
             try:
                 self.start()
                 sio.disconnect()
-                sio.connect(server, headers={"Authorization": sio.token})
+                sio.connect(server_url, headers={"Authorization": sio.token})
                 self.button.clicked.disconnect(self.conectar)
                 self.button.clicked.connect(self.desconectar)
                 self.conn()
@@ -120,21 +120,32 @@ class MainWindow(QMainWindow):
                 print(e)
                 self.error()
         else:
-            self.label.setText("Token not found.")
+            self.label.setText("Token or server not found.")
 
-    def obtener_token(self):
-        if os.path.exists('config.json'):
-            with open('config.json', 'r') as f:
-                config = json.load(f)
-                sio.token = config.get('token')
-                if sio.token:
-                    return sio.token
-        sio.token, ok = QInputDialog.getText(self, 'Input Dialog', 'Token:')
-        if ok and sio.token:
-            with open('config.json', 'w') as f:
-                json.dump({"token": sio.token}, f)
-            return sio.token
-        return None
+    def obtener_config(self):
+        config = load_config()
+
+        token = config.get('token')
+        if not token:
+            token, ok = QInputDialog.getText(self, 'Input Dialog', 'Token:')
+            if not ok or not token:
+                return None
+            config['token'] = token
+
+        server_url = config.get('server')
+        if not server_url:
+            server_url, ok = QInputDialog.getText(
+                self,
+                'Input Dialog',
+                'Servidor:',
+                text=server
+            )
+            if not ok or not server_url:
+                return None
+            config['server'] = server_url
+
+        save_config(token=config['token'], server=config['server'])
+        return config
 
     def desconectar(self):
         sio.disconnect()

--- a/utils.py
+++ b/utils.py
@@ -1,18 +1,39 @@
 import json
 import os
 
+
 def load_config():
     """Carga la configuración desde el archivo config.json si existe."""
     if os.path.exists('config.json'):
-        with open('config.json', 'r') as f:
-            config = json.load(f)
-            return config.get('token')
-    return None
+        try:
+            with open('config.json', 'r') as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+        return {
+            "token": config.get('token'),
+            "server": config.get('server')
+        }
+    return {}
 
-def save_config(token):
-    """Guarda el token en el archivo config.json."""
+
+def save_config(token=None, server=None):
+    """Guarda los valores de configuración proporcionados en el archivo config.json."""
+    config = {}
+    if os.path.exists('config.json'):
+        try:
+            with open('config.json', 'r') as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            config = {}
+
+    if token is not None:
+        config['token'] = token
+    if server is not None:
+        config['server'] = server
+
     with open('config.json', 'w') as f:
-        json.dump({"token": token}, f)
+        json.dump(config, f)
 
 def log(msg, sio, token):
     """Logea un mensaje y lo envía al servidor mediante socketio."""


### PR DESCRIPTION
## Summary
- update the config helpers to persist both the token and server host
- prompt for the server host when it is missing and use it when connecting
- include the default server host in the sample config file

## Testing
- python -m compileall ui.py utils.py communication.py

------
https://chatgpt.com/codex/tasks/task_e_68e57bf6ade88331ad7ec270fa64b76d